### PR TITLE
Add customizable page title

### DIFF
--- a/charts/showroom-single-pod/files/index.html
+++ b/charts/showroom-single-pod/files/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Showroom</title>
+    <title>{{ .Values.content.title }}</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <link rel="stylesheet" type="text/css" href="split.css">
     <link rel="stylesheet" type="text/css" href="tabs.css">

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -14,6 +14,7 @@ proxy:
   imagePullPolicy: IfNotPresent
 
 content:
+  title: Showroom
   # Only create a content pane, no other tabs will be available
   contentOnly: "false"
   image: ghcr.io/rhpds/showroom-content:prod

--- a/charts/showroom/files/index.html
+++ b/charts/showroom/files/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Showroom</title>
+    <title>{{ .Values.content.title }}</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <link rel="stylesheet" type="text/css" href="split.css">
     <link rel="stylesheet" type="text/css" href="tabs.css">

--- a/charts/showroom/values.yaml
+++ b/charts/showroom/values.yaml
@@ -39,6 +39,7 @@ home:
 # Ignored if using {"documentation":{"url":"..."}}
 #
 content:
+  title: Showroom
   image: ghcr.io/rhpds/showroom-content:latest
   repoUrl: https://github.com/rhpds/showroom_template_default.git
   repoRef: main


### PR DESCRIPTION
The default title "Showroom" is sometimes a bit misleading. Let's make it configurable.

Part of https://github.com/cloud-native-robotz-hackathon/infrastructure/issues/148