### PR TITLE
[zerotouch] Set cpu and memory requests/limits

### DIFF
--- a/charts/zerotouch/Chart.yaml
+++ b/charts/zerotouch/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.15
+version: 1.9.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zerotouch/templates/deployment.yaml
+++ b/charts/zerotouch/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
         - mountPath: /showroom/repo
           name: {{ .Release.Name }}-files
           subPath: repo
+        resources:
+          {{- toYaml .Values.git_cloner.resources | nindent 10 }}
       - name: antora-builder
         image: {{ .Values.antora.image }}
         env:
@@ -54,8 +56,11 @@ spec:
         - mountPath: /showroom/www
           name: {{ .Release.Name }}-files
           subPath: www
+        resources:
+          {{- toYaml .Values.antora.resources | nindent 10 }}
 {{- if eq .Values.setup_automation.setup "true" }}
-      - resources: {}
+      - resources:
+          {{- toYaml .Values.setup_automation.resources | nindent 10 }}
         terminationMessagePath: /dev/termination-log
         name: setup
         env:
@@ -125,7 +130,8 @@ spec:
 {{- end }}
       containers:
 {{- if eq .Values.runtime_automation.setup "true" }}
-      - resources: {}
+      - resources:
+          {{- toYaml .Values.runtime_automation.resources | nindent 10 }}
         terminationMessagePath: /dev/termination-log
         name: runner
         env:
@@ -227,6 +233,8 @@ spec:
         ports:
         - name: web
           containerPort: 8080
+        resources:
+          {{- toYaml .Values.proxy.resources | nindent 10 }}
 
       - name: content
         image: {{ .Values.content.image }}
@@ -262,6 +270,8 @@ spec:
           httpGet:
             path: /
             port: 8000
+        resources:
+          {{- toYaml .Values.content.resources | nindent 10 }}
 
 {{- if eq .Values.terminal.setup "true" }}
       - name: terminal
@@ -484,6 +494,8 @@ spec:
         ports:
         - containerPort: {{ .Values.cloud.port }}
           protocol: TCP
+        resources:
+          {{- toYaml .Values.cloud.resources | nindent 10 }}
 {{- end }}
 
 {{- if eq .Values.ironrdp.setup "true" }}
@@ -508,6 +520,8 @@ spec:
           protocol: TCP
         - containerPort: {{ .Values.ironrdp.port }}
           protocol: TCP
+        resources:
+          {{- toYaml .Values.ironrdp.resources | nindent 10 }}
 {{- end }}
       - name: monitoring
         image: {{ .Values.monitoring.image }}
@@ -526,6 +540,8 @@ spec:
         ports:
         - containerPort: {{ .Values.monitoring.port }}
           protocol: TCP
+        resources:
+          {{- toYaml .Values.monitoring.resources | nindent 10 }}
 
       volumes:
       - name: {{ .Release.Name }}-files

--- a/charts/zerotouch/values.yaml
+++ b/charts/zerotouch/values.yaml
@@ -19,6 +19,12 @@ route:
 
 proxy:
   image: quay.io/rhpds/nginx:1.25
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 satellite:
   url: ''
@@ -36,7 +42,7 @@ content:
   zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.1.0/nookbag-v0.1.0.zip"
   resources:
     limits:
-      memory: 64Mi
+      memory: 128Mi
     requests:
       cpu: 100m
       memory: 64Mi
@@ -87,7 +93,7 @@ wetty:
   base: "wetty"
   resources:
     limits:
-      memory: 256Mi
+      memory: 512Mi
     requests:
       cpu: 500m
       memory: 256Mi
@@ -151,7 +157,7 @@ cloud:
     limits:
       memory: 256Mi
     requests:
-      cpu: 500m
+      cpu: 250m
       memory: 256Mi
 
 ironrdp:
@@ -163,14 +169,32 @@ ironrdp:
   password: ""
   jetserver: "localhost:7171"
   tokengenserver: "localhost:8081"
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 setup_automation:
   setup: "true"
   image: quay.io/rhpds/setup-automation:v1.0.3
+  resources:
+    limits:
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
 
 runtime_automation:
   setup: "true"
   image: quay.io/rhpds/zerotouch-automation:v1.2.0
+  resources:
+    limits:
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
 
 automation:
   vault_password: ""
@@ -178,9 +202,27 @@ automation:
 monitoring:
   image: quay.io/rhpds/zt-monitoring:v1
   port: 9999
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 git_cloner:
   image: quay.io/rhpds/git-cloner:v1.1.2
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 antora:
   image: quay.io/rhpds/antora:v1.0.1
+  resources:
+    limits:
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi


### PR DESCRIPTION
- **Summary**
  - Introduces explicit `resources` (requests/limits) for all core ZeroTouch containers to improve scheduling predictability and cluster stability.
  - Increases or adds sane defaults in `values.yaml`; templates consume these via Helm toYaml binding.
  - Bumps chart version from 1.9.15 to 1.9.16.

- **Key changes**
  - `charts/zerotouch/templates/deployment.yaml`:
    - Add `resources` blocks sourced from `values.yaml` for:
      - `git_cloner`, `antora-builder`, `proxy`, `content`, `cloud`, `ironrdp`, `monitoring`
      - Conditional containers: `setup` (`setup_automation`), `runner` (`runtime_automation`)
  - `charts/zerotouch/values.yaml`:
    - New or updated resource defaults:
      - `proxy.resources` (new): requests 100m/128Mi; limits 256Mi
      - `content.resources`: limit 64Mi → 128Mi (requests unchanged: 100m/64Mi)
      - `wetty.resources`: limit 256Mi → 512Mi (requests unchanged: 500m/256Mi)
      - `cloud.resources`: cpu request 500m → 250m (mem unchanged: 256Mi req/limit)
      - `ironrdp.resources` (new): requests 100m/128Mi; limit 256Mi
      - `setup_automation.resources` (new): requests 100m/128Mi; limit 256Mi
      - `runtime_automation.resources` (new): requests 250m/256Mi; limit 512Mi
      - `monitoring.resources` (new): requests 100m/128Mi; limit 256Mi
      - `git_cloner.resources` (new): requests 50m/64Mi; limit 128Mi
      - `antora.resources` (new): requests 250m/256Mi; limit 512Mi
  - `charts/zerotouch/Chart.yaml`: version `1.9.15` → `1.9.16`

- **Motivation**
  - Provide clear resource envelopes for scheduler fairness and to reduce CPU throttling/OOM risk.
  - Allow operators to override via values as needed per cluster capacity.
