### PR TITLE
feat(showroom-single-pod): enable dev-mode in Antora

### DIFF
--- a/charts/showroom-single-pod/templates/deployment.yaml
+++ b/charts/showroom-single-pod/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
           value: "/showroom/www"
         - name: ANTORA_SITE_FILE
           value: {{ .Values.content.antoraPlaybook | quote }}
+        - name: ANTORA_ENABLE_DEV_MODE
+          value: {{ .Values.content.enableDevMode | quote }}
         volumeMounts:
         - mountPath: /showroom/repo
           name: {{ .Release.Name }}-files

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -19,6 +19,7 @@ content:
   repoUrl: https://github.com/rhpds/showroom_template_default.git
   repoRef: main
   antoraPlaybook: default-site.yml
+  enableDevMode: "false"
   zero_touch_ui_enabled: "true"
   zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.2.1/nookbag-v0.2.1.zip"
   user_data: |


### PR DESCRIPTION
This PR introduces a new variable `.content.enableDevMode` to the `showroom-single-pod` chart.

When set to true, this variable passes the ANTORA_ENABLE_DEV_MODE environment variable to the showroom container. This triggers the injection of dev-mode.js and enables the development extension in the underlying showroom image, which is useful for content development and debugging.