### PR TITLE
Add SHOWROOM_TABS env var for runtime tab override

### DIFF
--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -14,7 +14,7 @@ proxy:
   imagePullPolicy: IfNotPresent
 
 content:
-  image: quay.io/rhpds/showroom-content:v1.3.1
+  image: quay.io/rhpds/showroom-content:v1.4.0
   imagePullPolicy: IfNotPresent
   repoUrl: https://github.com/rhpds/showroom_template_default.git
   repoRef: main
@@ -57,10 +57,10 @@ wetty:
       memory: 256Mi
 
 git_cloner:
-  image: quay.io/rhpds/git-cloner:v1.1.2
+  image: quay.io/rhpds/git-cloner:v1.1.3
 
 antora:
-  image: quay.io/rhpds/antora:v1.1.1
+  image: quay.io/rhpds/antora:v1.2.0
 
 # To be fully implemented
 # codeserver:


### PR DESCRIPTION
## Summary

- Adds `content.tabs` value (default: empty string) to `showroom-single-pod` chart
- Passes `SHOWROOM_TABS` env var to the `antora-builder` init container
- When set to a JSON array of tab objects, the antora entrypoint overrides `ui-config.yml` tabs before build

Follows the same pattern as `ANTORA_ENABLE_DEV_MODE` in #48.

## Related PRs

- **showroom-images**: rhpds/showroom-images#37 (entrypoint `configure_tabs()` function)
- **showroom collection**: agnosticd/showroom#24 (Ansible variable plumbing)

## Example usage

```yaml
helm template showroom charts/showroom-single-pod \
  --set-json 'content.tabs=[{"name":"OCP Console","url":"https://console-openshift-console.apps.example.com"},{"name":"Terminal","type":"terminal"}]'
```

When `content.tabs` is empty (default), the content repo's `ui-config.yml` tabs are used unchanged.