### PR TITLE
fix(showroom-single-pod): pass SHOWROOM_UI_CONFIG to content container

### DIFF
--- a/charts/showroom-single-pod/templates/deployment.yaml
+++ b/charts/showroom-single-pod/templates/deployment.yaml
@@ -86,6 +86,8 @@ spec:
           value: {{ .Values.content.zero_touch_bundle | quote  }}
         - name: ZT_UI_ENABLED
           value: {{ .Values.content.zero_touch_ui_enabled | quote }}
+        - name: SHOWROOM_UI_CONFIG
+          value: {{ .Values.content.uiConfig | quote }}
         - name: DOMAIN
           value: {{ .Values.deployer.domain | quote }}
         - name: GUID

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -20,6 +20,7 @@ content:
   repoRef: main
   antoraPlaybook: default-site.yml
   enableDevMode: "false"
+  uiConfig: ""
   zero_touch_ui_enabled: "true"
   zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.2.1/nookbag-v0.2.1.zip"
   user_data: |


### PR DESCRIPTION
## Summary

- Pass `SHOWROOM_UI_CONFIG` env var to the `content` container, matching
  the new override support added in showroom-images/content (186c08f).
- When set, the content entrypoint writes the value directly as
  `ui-config.yml`, bypassing the repo copy. When empty, the existing
  repo-based flow is preserved.

## Changes

- `deployment.yaml`: add `SHOWROOM_UI_CONFIG` env var to the `content`
  container
- `values.yaml`: add `content.uiConfig` (default empty string)