### PR TITLE
Add nookbag health check sidecar, resource limits, and version bumps

### DIFF
--- a/charts/showroom-single-pod/Chart.yaml
+++ b/charts/showroom-single-pod/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.11
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/showroom-single-pod/templates/deployment.yaml
+++ b/charts/showroom-single-pod/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
           value: {{ .Values.content.antoraPlaybook | quote }}
         - name: ANTORA_ENABLE_DEV_MODE
           value: {{ .Values.content.enableDevMode | quote }}
+{{- if .Values.content.antoraUiBundleUrl }}
+        - name: ANTORA_UI_BUNDLE_URL
+          value: {{ .Values.content.antoraUiBundleUrl | quote }}
+{{- end }}
         volumeMounts:
         - mountPath: /showroom/repo
           name: {{ .Release.Name }}-files
@@ -71,6 +75,8 @@ spec:
         ports:
         - name: web
           containerPort: 8080
+        resources:
+          {{- toYaml .Values.proxy.resources | nindent 10 }}
 
       - name: content
         image: {{ .Values.content.image | quote }}
@@ -120,6 +126,8 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
           timeoutSeconds: 3
+        resources:
+          {{- toYaml .Values.content.resources | nindent 10 }}
 
 {{- if eq .Values.nookbag_sidecar.setup "true" }}
       - name: nookbag-sidecar

--- a/charts/showroom-single-pod/templates/deployment.yaml
+++ b/charts/showroom-single-pod/templates/deployment.yaml
@@ -110,10 +110,42 @@ spec:
           httpGet:
             path: /
             port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /
             port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+
+{{- if eq .Values.nookbag_sidecar.setup "true" }}
+      - name: nookbag-sidecar
+        image: {{ .Values.nookbag_sidecar.image | quote }}
+        imagePullPolicy: {{ .Values.nookbag_sidecar.imagePullPolicy | quote }}
+        env:
+        - name: HEALTHZ_PORT
+          value: "8090"
+        - name: HEALTHZ_BASE_URL
+          value: {{ .Values.nookbag_sidecar.baseUrl | quote }}
+        - name: NOOKBAG_BASE
+          value: {{ .Values.nookbag_sidecar.nookbagBase | quote }}
+        ports:
+        - name: healthz
+          containerPort: 8090
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8090
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          {{- toYaml .Values.nookbag_sidecar.resources | nindent 10 }}
+{{- end }}
 
 {{- if eq .Values.terminal.setup "true" }}
       - name: terminal

--- a/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
+++ b/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
@@ -69,6 +69,20 @@ data:
         }
 {{- end }}
 
+{{-   if eq .Values.nookbag_sidecar.setup "true" }}
+        location = /healthz {
+          proxy_pass http://127.0.0.1:8090/healthz;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /readyz {
+          proxy_pass http://127.0.0.1:8090/readyz;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+{{- end }}
+
 {{-   if eq .Values.novnc.setup "true" }}
         location ^~ /novnc {
           proxy_pass http://127.0.0.1:{{ .Values.novnc.port }};

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -80,7 +80,7 @@ wetty:
       memory: 256Mi
 
 git_cloner:
-  image: quay.io/rhpds/git-cloner:v1.1.3
+  image: quay.io/rhpds/git-cloner:v1.1.4
 
 antora:
   image: quay.io/rhpds/antora:v1.2.2

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -12,6 +12,13 @@ deployer:
 proxy:
   image: quay.io/rhpds/nginx:1.25
   imagePullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 5m
+      memory: 16Mi
 
 content:
   image: quay.io/rhpds/showroom-content:v1.4.1
@@ -19,6 +26,7 @@ content:
   repoUrl: https://github.com/rhpds/showroom_template_default.git
   repoRef: main
   antoraPlaybook: site.yml
+  antoraUiBundleUrl: ""
   enableDevMode: "false"
   uiConfig: ""
   zero_touch_ui_enabled: "true"
@@ -28,10 +36,10 @@ content:
 
 nookbag_sidecar:
   setup: "true"
-  image: quay.io/rhpds/nookbag-sidecar:v1.0.0
+  image: quay.io/rhpds/nookbag-sidecar:v1.0.1
   imagePullPolicy: IfNotPresent
   baseUrl: "http://localhost:8080"
-  nookbagBase: "/"
+  nookbagBase: ""
   resources:
     limits:
       cpu: 100m
@@ -65,6 +73,7 @@ wetty:
   base: "wetty"
   resources:
     limits:
+      cpu: 500m
       memory: 256Mi
     requests:
       cpu: 500m
@@ -74,7 +83,7 @@ git_cloner:
   image: quay.io/rhpds/git-cloner:v1.1.3
 
 antora:
-  image: quay.io/rhpds/antora:v1.2.1
+  image: quay.io/rhpds/antora:v1.2.2
 
 # To be fully implemented
 # codeserver:

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -26,6 +26,20 @@ content:
   user_data: |
     bastion_password: from_helm
 
+nookbag_sidecar:
+  setup: "true"
+  image: quay.io/rhpds/nookbag-sidecar:v1.0.0
+  imagePullPolicy: IfNotPresent
+  baseUrl: "http://localhost:8080"
+  nookbagBase: "/"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 16Mi
+
 terminal:
   setup: "true"
   image: quay.io/rhpds/openshift-showroom-terminal-ocp:latest

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -18,11 +18,11 @@ content:
   imagePullPolicy: IfNotPresent
   repoUrl: https://github.com/rhpds/showroom_template_default.git
   repoRef: main
-  antoraPlaybook: default-site.yml
+  antoraPlaybook: site.yml
   enableDevMode: "false"
   uiConfig: ""
   zero_touch_ui_enabled: "true"
-  zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.2.1/nookbag-v0.2.1.zip"
+  zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.3.2/nookbag-v0.3.2.zip"
   user_data: |
     bastion_password: from_helm
 


### PR DESCRIPTION
Adds a nookbag health check sidecar container to the showroom-single-pod chart, introduces resource limits across containers, and bumps several default image/bundle versions. These changes improve observability via dedicated `/healthz` and `/readyz` endpoints and ensure resource governance for all containers in the pod.

## Changes
- Add nookbag-sidecar container with configurable health check endpoints (`/healthz`, `/readyz`) proxied through nginx
- Add resource requests/limits for proxy, content, and nookbag-sidecar containers
- Add configurable liveness/readiness probe timing (`initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`) on the content container
- Bump nookbag UI bundle from v0.2.1 to v0.3.2
- Bump antora image from v1.2.1 to v1.2.2
- Change default Antora playbook from `default-site.yml` to `site.yml`
- Add support for custom `ANTORA_UI_BUNDLE_URL` environment variable
- Add missing CPU limit for wetty container

## Notes
- The nookbag sidecar is enabled by default (`nookbag_sidecar.setup: "true"`). Set to `"false"` to opt out.
- The default Antora playbook change from `default-site.yml` to `site.yml` may require content repos to have a `site.yml` at their root.