### PR TITLE
chore(showroom-single-pod): bump nookbag-sidecar default image from v1.0.1 to v1.0.2

### DIFF
--- a/charts/showroom-single-pod/Chart.yaml
+++ b/charts/showroom-single-pod/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -36,7 +36,7 @@ content:
 
 nookbag_sidecar:
   setup: "true"
-  image: quay.io/rhpds/nookbag-sidecar:v1.0.1
+  image: quay.io/rhpds/nookbag-sidecar:v1.0.2
   imagePullPolicy: IfNotPresent
   baseUrl: "http://localhost:8080"
   nookbagBase: ""


### PR DESCRIPTION
Updates the default `nookbag-sidecar` image tag from `v1.0.1` to `v1.0.2` in the `showroom-single-pod` chart to pick up the latest sidecar release.

## Changes
- Bump `nookbag_sidecar.image` default from `quay.io/rhpds/nookbag-sidecar:v1.0.1` to `v1.0.2`
- Increment chart version from `2.1.0` to `2.1.1`