### PR TITLE
ci(release): enable auto-generated release notes for helm chart releases

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,1 @@
+generate-release-notes: true

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -30,5 +30,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
+        with:
+          config: .github/cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Configures the `helm/chart-releaser-action` to automatically generate release notes when publishing new Helm chart versions to GitHub Releases.

## Changes
- Add `.github/cr.yaml` config file with `generate-release-notes: true`
- Update `release-helm.yaml` workflow to pass the new config file to `chart-releaser-action`