### PR TITLE
fix(wetty): allow iframe embedding with --allow-iframe flag

### DIFF
--- a/charts/showroom-single-pod/Chart.yaml
+++ b/charts/showroom-single-pod/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/showroom-single-pod/templates/deployment.yaml
+++ b/charts/showroom-single-pod/templates/deployment.yaml
@@ -185,6 +185,7 @@ spec:
         args:
         - --base="/{{ .Values.wetty.base }}/"
         - --port={{ .Values.wetty.port }}
+        - --allow-iframe=true
 {{-   if eq .Values.wetty.ssh.autoSshToBastion "true" }}
         - --ssh-host={{ .Values.wetty.ssh.sshHost }}
         - --ssh-port={{ .Values.wetty.ssh.sshPort }}


### PR DESCRIPTION
Wetty's iframe check was failing when running inside a pod, preventing it from loading within the showroom UI. This adds the `--allow-iframe=true` flag to the wetty container args so it permits being embedded in an iframe.

## Changes
- Add `--allow-iframe=true` to the wetty container arguments in the showroom-single-pod deployment template