### PR TITLE
Configure nginx to inject execute-listener.js for send-to-terminal functionality

### DIFF
--- a/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
+++ b/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
@@ -39,9 +39,9 @@ data:
 
 {{-   if eq .Values.terminal.setup "true" }}
         # Terminal locations - supports /terminal, /terminal1, /terminal2, /tty, /tty1, /tty2, etc.
-        location ~ ^/(terminal[0-9]*|tty[0-9]*)/ {
+        location ~ ^/(terminal[0-9]*|tty[0-9]*) {
           proxy_pass http://127.0.0.1:{{ .Values.terminal.port }};
-          rewrite ^/(terminal[0-9]*|tty[0-9]*)/(.*)$ /$2 break;
+          rewrite ^/(terminal[0-9]*|tty[0-9]*)(.*)$ /$2 break;
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;

--- a/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
+++ b/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
@@ -38,9 +38,17 @@ data:
         }
 
 {{-   if eq .Values.terminal.setup "true" }}
-        location /terminal/ {
+        # Serve execute-listener.js for send-to-terminal functionality
+        location /execute-listener.js {
+          proxy_pass http://127.0.0.1:8888/execute-listener.js;
+          default_type application/javascript;
+          add_header Cache-Control "no-cache, no-store, must-revalidate";
+        }
+
+        # Terminal locations - supports /terminal, /terminal1, /terminal2, /tty, /tty1, /tty2, etc.
+        location ~ ^/(terminal[0-9]*|tty[0-9]*)/ {
           proxy_pass http://127.0.0.1:{{ .Values.terminal.port }};
-          rewrite ^/terminal/(.*)$ /$1 break;
+          rewrite ^/(terminal[0-9]*|tty[0-9]*)/(.*)$ /$2 break;
 
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
@@ -51,6 +59,14 @@ data:
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header Host $http_host;
           proxy_set_header X-NginX-Proxy true;
+
+          # Disable compression so sub_filter works
+          proxy_set_header Accept-Encoding "";
+
+          # Inject execute-listener.js into terminal HTML
+          sub_filter '</body>' '<script src="/execute-listener.js"></script></body>';
+          sub_filter_once on;
+          sub_filter_types text/html;
         }
 {{- end }}
 

--- a/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
+++ b/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
@@ -38,13 +38,6 @@ data:
         }
 
 {{-   if eq .Values.terminal.setup "true" }}
-        # Serve execute-listener.js for send-to-terminal functionality
-        location /execute-listener.js {
-          proxy_pass http://127.0.0.1:8888/execute-listener.js;
-          default_type application/javascript;
-          add_header Cache-Control "no-cache, no-store, must-revalidate";
-        }
-
         # Terminal locations - supports /terminal, /terminal1, /terminal2, /tty, /tty1, /tty2, etc.
         location ~ ^/(terminal[0-9]*|tty[0-9]*)/ {
           proxy_pass http://127.0.0.1:{{ .Values.terminal.port }};
@@ -59,14 +52,6 @@ data:
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header Host $http_host;
           proxy_set_header X-NginX-Proxy true;
-
-          # Disable compression so sub_filter works
-          proxy_set_header Accept-Encoding "";
-
-          # Inject execute-listener.js into terminal HTML
-          sub_filter '</body>' '<script src="/execute-listener.js"></script></body>';
-          sub_filter_once on;
-          sub_filter_types text/html;
         }
 {{- end }}
 


### PR DESCRIPTION
…nctionality

Updates nginx configuration in showroom-single-pod chart to:
- Proxy execute-listener.js from terminal container port 8888
- Inject execute-listener.js script into terminal HTML via sub_filter
- Disable compression on terminal locations for sub_filter to work
- Support multiple terminal paths: /terminal, /tty, /tty1, /tty2, etc.

Requires terminal image with execute-listener.js support.