### PR TITLE
Add navbar logo support, make imagePullPolicy configurable, and clean up chart templates

### DIFF
--- a/charts/showroom-single-pod/Chart.yaml
+++ b/charts/showroom-single-pod/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.4
+version: 2.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/showroom-single-pod/templates/deployment.yaml
+++ b/charts/showroom-single-pod/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -207,7 +207,7 @@ spec:
 {{- if eq .Values.terminal.setup "true" }}
       - name: terminal
         image: {{ .Values.terminal.image | quote }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.terminal.imagePullPolicy | quote }}
         env:
         - name: NAMESPACE
           valueFrom:
@@ -230,7 +230,7 @@ spec:
 {{- if eq .Values.wetty.setup "true" }}
       - name: wetty
         image: {{ .Values.wetty.image | quote }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.wetty.imagePullPolicy | quote }}
         args:
         - --base="/{{ .Values.wetty.base }}/"
         - --port={{ .Values.wetty.port }}
@@ -259,7 +259,7 @@ spec:
 {{- if eq .Values.novnc.setup "true" }}
       - name: novnc
         image: {{ .Values.novnc.image | quote }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.novnc.imagePullPolicy | quote }}
         args:
         - websockify
         - --web=/www
@@ -274,8 +274,6 @@ spec:
 
       volumes:
       - name: {{ .Release.Name }}-files
-        emptyDir: {}
-      - name: showroom
         emptyDir: {}
       - name: user-data
         configMap:

--- a/charts/showroom-single-pod/templates/deployment.yaml
+++ b/charts/showroom-single-pod/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
         - name: ANTORA_UI_BUNDLE_URL
           value: {{ .Values.content.antoraUiBundleUrl | quote }}
 {{- end }}
+{{- if .Values.content.antoraNavbarLogo }}
+        - name: ANTORA_KEY_NAVBAR_LOGO
+          value: {{ .Values.content.antoraNavbarLogo | quote }}
+{{- end }}
         volumeMounts:
         - mountPath: /showroom/repo
           name: {{ .Release.Name }}-files

--- a/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
+++ b/charts/showroom-single-pod/templates/proxy/configmap-nginx-config.yaml
@@ -1,9 +1,9 @@
 ---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-proxy-config
-  namespace: {{ .Release.Namespace}}
-apiVersion: v1
+  namespace: {{ .Release.Namespace }}
 data:
   nginx.conf: |
     #daemon off;

--- a/charts/showroom-single-pod/templates/proxy/configmap-user-data.yaml
+++ b/charts/showroom-single-pod/templates/proxy/configmap-user-data.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-userdata
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
 data:
   user_data.yml: |
 {{ .Values.content.user_data | indent 4 }}

--- a/charts/showroom-single-pod/templates/proxy/route.yaml
+++ b/charts/showroom-single-pod/templates/proxy/route.yaml
@@ -3,7 +3,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
   annotations:
     haproxy.router.openshift.io/timeout: 1h
     haproxy.router.openshift.io/timeout-tunnel: 1h

--- a/charts/showroom-single-pod/templates/proxy/service.yaml
+++ b/charts/showroom-single-pod/templates/proxy/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/showroom-single-pod/templates/pvc.yaml
+++ b/charts/showroom-single-pod/templates/pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-terminal-lab-user-home
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -23,14 +23,15 @@ proxy:
 content:
   image: quay.io/rhpds/showroom-content:v1.4.1
   imagePullPolicy: IfNotPresent
-  repoUrl: https://github.com/rhpds/showroom_template_default.git
+  repoUrl: https://github.com/rhpds/showroom_template_nookbag.git
   repoRef: main
   antoraPlaybook: site.yml
   antoraUiBundleUrl: ""
+  antoraNavbarLogo: ""
   enableDevMode: "false"
   uiConfig: ""
   zero_touch_ui_enabled: "true"
-  zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.3.2/nookbag-v0.3.2.zip"
+  zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.3.4/nookbag-v0.3.4.zip"
   user_data: |
     bastion_password: from_helm
 

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -57,7 +57,7 @@ nookbag_sidecar:
 
 runtime_automation:
   setup: "false"
-  image: quay.io/rhpds/showroom-automation:v1.0.0
+  image: quay.io/rhpds/zt-runner:v2.5.0
   imagePullPolicy: Always
   port: 8501
   environment_variables: {}

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -30,8 +30,14 @@ content:
   antoraNavbarLogo: ""
   enableDevMode: "false"
   uiConfig: ""
-  zero_touch_ui_enabled: "true"
   zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.3.4/nookbag-v0.3.4.zip"
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
   user_data: |
     bastion_password: from_helm
 
@@ -66,6 +72,7 @@ runtime_automation:
 terminal:
   setup: "true"
   image: quay.io/rhpds/openshift-showroom-terminal-ocp:latest
+  imagePullPolicy: IfNotPresent
   port: 7681
   resources:
     limits:
@@ -84,6 +91,7 @@ terminal:
 wetty:
   setup: "true"
   image: quay.io/rhpds/wetty:v2.5
+  imagePullPolicy: IfNotPresent
   port: 8001
   base: "wetty"
   resources:
@@ -98,25 +106,14 @@ git_cloner:
   image: quay.io/rhpds/git-cloner:v1.1.4
 
 antora:
-  image: quay.io/rhpds/antora:v1.2.2
-
-# To be fully implemented
-# codeserver:
-#   setup: "false"
-#   image: quay.io/rhpds/code-server:latest
-#   resources:
-#     limits:
-#       memory: 512Mi
-#     requests:
-#       cpu: 500m
-#       memory: 512Mi
+  image: quay.io/rhpds/antora:v1.2.4
 
 novnc:
   setup: "false"
   image: ghcr.io/rhpds/showroom-novnc:latest
+  imagePullPolicy: IfNotPresent
   port: 6080
   vncServer: 127.0.0.1:5900
-  password: password
   resources:
     limits:
       memory: 256Mi


### PR DESCRIPTION
Adds support for a custom Antora navbar logo via a new `content.antoraNavbarLogo` value, makes `imagePullPolicy` configurable for the terminal, wetty, and novnc containers (previously hardcoded), and cleans up chart templates with consistent formatting and dependency bumps.

## Changes
- Add `content.antoraNavbarLogo` value and pass it as `ANTORA_KEY_NAVBAR_LOGO` env var to the content container
- Make `imagePullPolicy` configurable for terminal, wetty, and novnc containers instead of hardcoding `IfNotPresent`
- Add resource limits/requests for the content container
- Bump nookbag from v0.3.2 to v0.3.4 and antora from v1.2.2 to v1.2.4
- Switch default content repo to `showroom_template_nookbag`
- Remove unused `showroom` emptyDir volume, stale `zero_touch_ui_enabled` default, novnc `password` default, and commented-out codeserver block
- Fix inconsistent `{{ .Release.Namespace }}` spacing and `apiVersion`/`kind` ordering across templates
- Bump chart version to 2.1.5

## Notes
- The default content repo URL changed from `showroom_template_default` to `showroom_template_nookbag` — existing deployments relying on the default may need to explicitly set `content.repoUrl`.
- The `zero_touch_ui_enabled` and `novnc.password` values were removed from defaults — verify no downstream consumers depend on these being set by the chart.