### PR TITLE
chore(showroom-single-pod): bump nookbag to v0.3.6 and wetty to v2.7.6

### DIFF
--- a/charts/showroom-single-pod/Chart.yaml
+++ b/charts/showroom-single-pod/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.5
+version: 2.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -30,7 +30,7 @@ content:
   antoraNavbarLogo: ""
   enableDevMode: "false"
   uiConfig: ""
-  zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.3.4/nookbag-v0.3.4.zip"
+  zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.3.6/nookbag-v0.3.6.zip"
   resources:
     limits:
       cpu: 100m
@@ -90,7 +90,7 @@ terminal:
 
 wetty:
   setup: "true"
-  image: quay.io/rhpds/wetty:v2.5
+  image: quay.io/rhpds/wetty:v2.7.6
   imagePullPolicy: IfNotPresent
   port: 8001
   base: "wetty"


### PR DESCRIPTION
Update the default nookbag and wetty versions in the showroom-single-pod chart to pull in UI improvements, connection resilience fixes, and terminal theme support.

## Changes
- Bump nookbag zero-touch bundle from v0.3.4 to v0.3.6
- Bump wetty image from v2.5 to v2.7.6
- Increment chart version from 2.1.5 to 2.1.6

## Nookbag changes (v0.3.4 → v0.3.6)
- [rhpds/nookbag#59](https://github.com/rhpds/nookbag/pull/59) — Replace floating view switcher with right-edge popout and modernize UI
- [rhpds/nookbag#60](https://github.com/rhpds/nookbag/pull/60) — Remove padding and use transparent background for terminal iframes

## Wetty image changes (v2.5 → v2.7.6)

showroom-images (container build):
- [rhpds/showroom-images#56](https://github.com/rhpds/showroom-images/pull/56) — Build wetty from source using andrew-jones/wetty fork
- [rhpds/showroom-images#57](https://github.com/rhpds/showroom-images/pull/57) — Fix wetty OCP entrypoint and add postMessage execute-listener
- [rhpds/showroom-images#58](https://github.com/rhpds/showroom-images/pull/58) — Simplify execute-listener to target wetty-only with debug logging
- [rhpds/showroom-images#60](https://github.com/rhpds/showroom-images/pull/60) — Pin wetty build to v2.7.4 release tag
- [rhpds/showroom-images#61](https://github.com/rhpds/showroom-images/pull/61) — Bump wetty version to v2.7.5
- [rhpds/showroom-images#62](https://github.com/rhpds/showroom-images/pull/62) — Bump wetty version to v2.7.6

andrew-jones/wetty (upstream fork):
- [andrew-jones/wetty#1](https://github.com/andrew-jones/wetty/pull/1) — Prevent socket disconnects in background tabs
- [andrew-jones/wetty#2](https://github.com/andrew-jones/wetty/pull/2) — Harden SSH and WebSocket resilience against idle drops and browser throttling
- [andrew-jones/wetty#3](https://github.com/andrew-jones/wetty/pull/3) — Add terminal color theme support via CLI and URL query param