### PR TITLE
feat(showroom-single-pod): bump content and git-cloner image versions

### DIFF
--- a/charts/showroom-single-pod/Chart.yaml
+++ b/charts/showroom-single-pod/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.6
+version: 2.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/showroom-single-pod/values.yaml
+++ b/charts/showroom-single-pod/values.yaml
@@ -21,7 +21,7 @@ proxy:
       memory: 16Mi
 
 content:
-  image: quay.io/rhpds/showroom-content:v1.4.1
+  image: quay.io/rhpds/showroom-content:v1.4.2
   imagePullPolicy: IfNotPresent
   repoUrl: https://github.com/rhpds/showroom_template_nookbag.git
   repoRef: main
@@ -103,7 +103,7 @@ wetty:
       memory: 256Mi
 
 git_cloner:
-  image: quay.io/rhpds/git-cloner:v1.1.4
+  image: quay.io/rhpds/git-cloner:v1.1.5
 
 antora:
   image: quay.io/rhpds/antora:v1.2.4


### PR DESCRIPTION
Updates the showroom-single-pod Helm chart to use the latest container image versions for the content and git-cloner sidecars, and increments the chart version accordingly.

## Changes
- Bump `showroom-content` image from v1.4.1 to v1.4.2
- Bump `git-cloner` image from v1.1.4 to v1.1.5
- Increment chart version from 2.1.6 to 2.1.7